### PR TITLE
ci(web-client): limit action triggering by path

### DIFF
--- a/.github/workflows/web-client.yaml
+++ b/.github/workflows/web-client.yaml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    paths:
+      - 'web-client/**'
 
 defaults:
   run:


### PR DESCRIPTION
This avoids running the web-client actions on pushes and PRs that don't touch the web-client code.