### PR TITLE
test(web-client): add story for the Ionic theme

### DIFF
--- a/web-client/src/stories/theme.html
+++ b/web-client/src/stories/theme.html
@@ -1,0 +1,78 @@
+<ion-content>
+  <h1>Nautilus theme</h1>
+
+  Based on the
+  <a
+    href="https://www.figma.com/file/zYVHu1EwCIDCbQp8rFscyA/Nautilus-Branding?node-id=23%3A128"
+    >Nautilus Branding UI Kit</a
+  >.
+
+  <ion-card>
+    <ion-card-header
+      ><ion-card-title>Ionic Colors</ion-card-title
+      ><ion-card-subtitle
+        >(see
+        <a href="https://ionicframework.com/docs/theming/colors">docs</a
+        >)</ion-card-subtitle
+      ></ion-card-header
+    >
+    <ion-card-content>
+      <div>
+        <ion-button shape="round" color="primary">Primary</ion-button>
+        <ion-button shape="round" color="secondary">Secondary</ion-button>
+        <ion-button shape="round" color="tertiary">Tertiary</ion-button>
+      </div>
+
+      <div>
+        <ion-button shape="round" color="success">Success</ion-button>
+        <ion-button shape="round" color="warning">Warning</ion-button>
+        <ion-button shape="round" color="danger">Danger</ion-button>
+      </div>
+
+      <div>
+        <ion-button shape="round" color="light">Light</ion-button>
+        <ion-button shape="round" color="medium">Medium</ion-button>
+        <ion-button shape="round" color="dark">Dark</ion-button>
+      </div></ion-card-content
+    >
+  </ion-card>
+
+  <ion-card>
+    <ion-card-header><ion-card-title>Outlines</ion-card-title></ion-card-header>
+    <ion-card-content>
+      <div>
+        <ion-button shape="round" fill="outline" color="primary"
+          >Primary</ion-button
+        >
+        <ion-button shape="round" fill="outline" color="secondary"
+          >Secondary</ion-button
+        >
+        <ion-button shape="round" fill="outline" color="tertiary"
+          >Tertiary</ion-button
+        >
+      </div>
+
+      <div>
+        <ion-button shape="round" fill="outline" color="success"
+          >Success</ion-button
+        >
+        <ion-button shape="round" fill="outline" color="warning"
+          >Warning</ion-button
+        >
+        <ion-button shape="round" fill="outline" color="danger"
+          >Danger</ion-button
+        >
+      </div>
+
+      <div>
+        <ion-button shape="round" fill="outline" color="light"
+          >Light</ion-button
+        >
+        <ion-button shape="round" fill="outline" color="medium"
+          >Medium</ion-button
+        >
+        <ion-button shape="round" fill="outline" color="dark">Dark</ion-button>
+      </div></ion-card-content
+    >
+  </ion-card>
+</ion-content>

--- a/web-client/src/stories/theme.stories.ts
+++ b/web-client/src/stories/theme.stories.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { Meta, Story } from '@storybook/angular';
+
+export default {
+  title: 'Theme',
+} as Meta;
+
+export const Theme: Story<void> = () => ThemeComponent;
+
+const ThemeComponent: Component = {
+  templateUrl: './theme.html',
+};


### PR DESCRIPTION
- From #28

This story gives us a quick view of how the Nautilus brand palette maps to the Ionic theme.

(This could also be a starting point for a [design system](https://storybook.js.org/tutorials/design-systems-for-developers/) for the Nautilus brand.)