### PR TITLE
test(web-client): fix coverage reporting

### DIFF
--- a/web-client/src/test.ts
+++ b/web-client/src/test.ts
@@ -19,13 +19,26 @@ declare const require: {
     <T>(id: string): T;
   };
 };
-
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
+const context = require.context(
+  './',
+  true,
+  // XXX: Work around Angular not reporting coverage for all files.
+  //
+  // In our case, we want to include everything except for:
+  //  * Storybook stories
+  //  * `main.ts`, because of platform configuration side effects.
+  //    (This avoids "Error: A platform with a different configuration has been created.")
+  //
+  // See also the include / exclude patterns in `tsconfig.spec.json`.
+  //
+  // Upstream issue: https://github.com/angular/angular-cli/issues/1735
+  /(?<!\/main|\.stories)\.ts$/
+);
 // And load the modules.
 context.keys().map(context);

--- a/web-client/tsconfig.spec.json
+++ b/web-client/tsconfig.spec.json
@@ -1,4 +1,5 @@
 /* To learn more about this file see: https://angular.io/config/tsconfig. */
+/* XXX: See test.ts for the include / exclude patterns. */
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
@@ -6,5 +7,6 @@
     "types": ["jasmine"]
   },
   "files": ["src/test.ts", "src/polyfills.ts"],
-  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/main.ts", "src/**/*.stories.ts"]
 }


### PR DESCRIPTION
This works around upstream Angular issue:

https://github.com/angular/angular-cli/issues/1735

This will decrease the reported coverage percentage, but the adjusted number should actually be correct now.