### PR TITLE
ci(web-client): disable ng e2e's webdriverUpdate behaviour for GitHub Actions

### DIFF
--- a/.github/workflows/web-client.yaml
+++ b/.github/workflows/web-client.yaml
@@ -1,6 +1,7 @@
 on:
   push:
     paths:
+      - '.github/workflows/web-client.yaml'
       - 'web-client/**'
 
 defaults:

--- a/.github/workflows/web-client.yaml
+++ b/.github/workflows/web-client.yaml
@@ -51,7 +51,19 @@ jobs:
       # See https://github.com/angular/angular-cli/issues/6286
       # See also the CI config in protractor.conf.js
       - name: Test (E2E / Protractor)
-        run: npm run e2e
+        # XXX: Disable the default "webdriverUpdate" behaviour for GitHub Actions.
+        #
+        # The GitHub Actions virtual environment already has matching versions of Chrome and ChromeDriver installed:
+        # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#browsers-and-drivers
+        #
+        # Without this flag, "ng e2e" will download the latest ChromeDriver, which will fail with a version mismatch
+        # error during the windows of time that a new Chrome major version has been released, but the GitHub image
+        # hasn't been updated yet.
+        #
+        # Note: This flag is not actually documented as part of "ng e2e", but see:
+        # https://stackoverflow.com/a/54757277
+        # https://ngrefs.com/cli/builder-protractor#webdriverUpdate
+        run: npm run e2e -- --webdriverUpdate=false
 
       - name: Check (eslint)
         run: npm run lint

--- a/web-client/e2e/protractor.conf.js
+++ b/web-client/e2e/protractor.conf.js
@@ -49,3 +49,19 @@ if (process.env["CI"]) {
     },
   };
 }
+
+// If CHROMEWEBDRIVER is set, use that as a base directory for chromedriver, rather than invoking webdriver-manager.
+//
+// This is intended to work with GitHub Actions:
+// https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#browsers-and-drivers
+// https://github.com/actions/virtual-environments/blob/ubuntu20/20210726.1/images/linux/scripts/installers/google-chrome.sh#L56-L67
+//
+// Docs:
+// https://github.com/angular/protractor/blob/6.0.0/lib/config.ts#L68-L76
+if (process.env["CHROMEWEBDRIVER"]) {
+  /** @type { import("protractor").Config } */
+  exports.config = {
+    ...exports.config,
+    chromeDriver: process.env["CHROMEWEBDRIVER"] + "/chromedriver",
+  };
+}


### PR DESCRIPTION
This should avoid the e2e tests breaking whenever the GitHub Actions
virtual environment lags behind the latest Chrome major version release.