### PR TITLE
test(web-client): better page route tests

### DIFF
--- a/web-client/src/app/views/home/home.page.spec.ts
+++ b/web-client/src/app/views/home/home.page.spec.ts
@@ -14,7 +14,6 @@ describe('HomePage', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [HomePage],
         imports: [
           IonicModule.forRoot(),
           RouterTestingModule.withRoutes(routes),

--- a/web-client/src/app/views/home/home.page.spec.ts
+++ b/web-client/src/app/views/home/home.page.spec.ts
@@ -1,10 +1,13 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
+import { routes } from '../../app-routing.module';
 import { HomePage } from './home.page';
 
 describe('HomePage', () => {
+  let router: Router;
   let component: HomePage;
   let fixture: ComponentFixture<HomePage>;
 
@@ -12,9 +15,15 @@ describe('HomePage', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [HomePage],
-        imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
+        imports: [
+          IonicModule.forRoot(),
+          RouterTestingModule.withRoutes(routes),
+          SharedModule,
+        ],
       }).compileComponents();
 
+      router = TestBed.inject(Router);
+      router.navigate(['home']);
       fixture = TestBed.createComponent(HomePage);
       component = fixture.componentInstance;
       fixture.detectChanges();

--- a/web-client/src/app/views/landing/landing.page.spec.ts
+++ b/web-client/src/app/views/landing/landing.page.spec.ts
@@ -22,6 +22,7 @@ describe('LandingPage', () => {
       }).compileComponents();
 
       router = TestBed.inject(Router);
+      router.navigate(['landing']);
       fixture = TestBed.createComponent(LandingPage);
       component = fixture.componentInstance;
       fixture.detectChanges();
@@ -33,10 +34,10 @@ describe('LandingPage', () => {
   });
 
   it('navigates to wallet', async (): Promise<void> => {
-    await verifyNavigationTrigger(router, fixture, '/wallet');
+    await verifyNavigationTrigger(router, fixture, '/landing', '/wallet');
   });
 
   it('navigates to register', async (): Promise<void> => {
-    await verifyNavigationTrigger(router, fixture, '/register');
+    await verifyNavigationTrigger(router, fixture, '/landing', '/register');
   });
 });

--- a/web-client/src/app/views/landing/landing.page.spec.ts
+++ b/web-client/src/app/views/landing/landing.page.spec.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
 import { verifyNavigationTrigger } from '../../../tests/test.helpers';
+import { getTranslocoTestingModule } from '../../../tests/transloco.helpers';
 import { routes } from '../../app-routing.module';
 import { LandingPage } from './landing.page';
 
@@ -17,6 +18,7 @@ describe('LandingPage', () => {
         imports: [
           IonicModule.forRoot(),
           RouterTestingModule.withRoutes(routes),
+          getTranslocoTestingModule(),
         ],
       }).compileComponents();
 

--- a/web-client/src/app/views/landing/landing.page.spec.ts
+++ b/web-client/src/app/views/landing/landing.page.spec.ts
@@ -14,7 +14,6 @@ describe('LandingPage', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [LandingPage],
         imports: [
           IonicModule.forRoot(),
           RouterTestingModule.withRoutes(routes),

--- a/web-client/src/app/views/login/login.page.spec.ts
+++ b/web-client/src/app/views/login/login.page.spec.ts
@@ -22,6 +22,7 @@ describe('LoginPage', () => {
       }).compileComponents();
 
       router = TestBed.inject(Router);
+      router.navigate(['login']);
       fixture = TestBed.createComponent(LoginPage);
       component = fixture.componentInstance;
       fixture.detectChanges();
@@ -33,10 +34,10 @@ describe('LoginPage', () => {
   });
 
   it('navigates to wallet', async (): Promise<void> => {
-    await verifyNavigationTrigger(router, fixture, '/wallet');
+    await verifyNavigationTrigger(router, fixture, '/login', '/wallet');
   });
 
   it('navigates to register', async (): Promise<void> => {
-    await verifyNavigationTrigger(router, fixture, '/register');
+    await verifyNavigationTrigger(router, fixture, '/login', '/register');
   });
 });

--- a/web-client/src/app/views/login/login.page.spec.ts
+++ b/web-client/src/app/views/login/login.page.spec.ts
@@ -14,7 +14,6 @@ describe('LoginPage', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [LoginPage],
         imports: [
           IonicModule.forRoot(),
           RouterTestingModule.withRoutes(routes),

--- a/web-client/src/app/views/register/register.page.spec.ts
+++ b/web-client/src/app/views/register/register.page.spec.ts
@@ -22,6 +22,7 @@ describe('RegisterPage', () => {
       }).compileComponents();
 
       router = TestBed.inject(Router);
+      router.navigate(['register']);
       fixture = TestBed.createComponent(RegisterPage);
       component = fixture.componentInstance;
       fixture.detectChanges();
@@ -33,6 +34,6 @@ describe('RegisterPage', () => {
   });
 
   it('navigates to login', async (): Promise<void> => {
-    await verifyNavigationTrigger(router, fixture, '/login');
+    await verifyNavigationTrigger(router, fixture, '/register', '/login');
   });
 });

--- a/web-client/src/app/views/register/register.page.spec.ts
+++ b/web-client/src/app/views/register/register.page.spec.ts
@@ -14,7 +14,6 @@ describe('RegisterPage', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [RegisterPage],
         imports: [
           IonicModule.forRoot(),
           RouterTestingModule.withRoutes(routes),

--- a/web-client/src/app/views/send-funds/send-funds.page.spec.ts
+++ b/web-client/src/app/views/send-funds/send-funds.page.spec.ts
@@ -1,9 +1,12 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
+import { routes } from '../../app-routing.module';
 import { SendFundsPage } from './send-funds.page';
 
 describe('SendFundsPage', () => {
+  let router: Router;
   let component: SendFundsPage;
   let fixture: ComponentFixture<SendFundsPage>;
 
@@ -11,9 +14,14 @@ describe('SendFundsPage', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [SendFundsPage],
-        imports: [IonicModule.forRoot(), RouterTestingModule],
+        imports: [
+          IonicModule.forRoot(),
+          RouterTestingModule.withRoutes(routes),
+        ],
       }).compileComponents();
 
+      router = TestBed.inject(Router);
+      router.navigate(['home']);
       fixture = TestBed.createComponent(SendFundsPage);
       component = fixture.componentInstance;
       fixture.detectChanges();

--- a/web-client/src/app/views/send-funds/send-funds.page.spec.ts
+++ b/web-client/src/app/views/send-funds/send-funds.page.spec.ts
@@ -13,7 +13,6 @@ describe('SendFundsPage', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [SendFundsPage],
         imports: [
           IonicModule.forRoot(),
           RouterTestingModule.withRoutes(routes),

--- a/web-client/src/app/views/wallet/wallet.page.spec.ts
+++ b/web-client/src/app/views/wallet/wallet.page.spec.ts
@@ -24,6 +24,7 @@ describe('WalletPage', () => {
       }).compileComponents();
 
       router = TestBed.inject(Router);
+      router.navigate(['wallet']);
       fixture = TestBed.createComponent(WalletPage);
       component = fixture.componentInstance;
       fixture.detectChanges();
@@ -35,6 +36,11 @@ describe('WalletPage', () => {
   });
 
   it('navigates to send funds', async (): Promise<void> => {
-    await verifyNavigationTrigger(router, fixture, '/wallet/send-funds');
+    await verifyNavigationTrigger(
+      router,
+      fixture,
+      '/wallet',
+      '/wallet/send-funds'
+    );
   });
 });

--- a/web-client/src/app/views/wallet/wallet.page.spec.ts
+++ b/web-client/src/app/views/wallet/wallet.page.spec.ts
@@ -15,7 +15,6 @@ describe('WalletPage', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [WalletPage],
         imports: [
           IonicModule.forRoot(),
           RouterTestingModule.withRoutes(routes),

--- a/web-client/src/tests/test.helpers.ts
+++ b/web-client/src/tests/test.helpers.ts
@@ -13,9 +13,10 @@ import { Router } from '@angular/router';
 export const verifyNavigationTrigger = async (
   router: Router,
   fixture: ComponentFixture<any>,
+  urlBeforeClick: string,
   routerLink: string
 ): Promise<void> => {
-  expect(router.url).toBe('/');
+  expect(router.url).toBe(urlBeforeClick);
   const trigger = getElementWithLink(fixture.debugElement, routerLink);
   trigger.nativeElement.click();
   await fixture.whenStable();

--- a/web-client/src/tests/transloco.helpers.ts
+++ b/web-client/src/tests/transloco.helpers.ts
@@ -1,0 +1,25 @@
+import {
+  TranslocoTestingModule,
+  TranslocoTestingOptions,
+} from '@ngneat/transloco';
+import * as en from '../assets/i18n/en.json';
+import * as fr from '../assets/i18n/fr.json';
+
+/**
+ * Docs: {@link https://ngneat.github.io/transloco/docs/unit-testing/}
+ *
+ * This should match the config in {@link TranslocoRootModule}.
+ */
+export const getTranslocoTestingModule = (
+  options: TranslocoTestingOptions = {}
+) =>
+  TranslocoTestingModule.forRoot({
+    langs: { en, fr },
+    translocoConfig: {
+      availableLangs: ['en', 'fr'],
+      defaultLang: 'en',
+      fallbackLang: 'en',
+    },
+    preloadLangs: true,
+    ...options,
+  });

--- a/web-client/tsconfig.spec.json
+++ b/web-client/tsconfig.spec.json
@@ -4,7 +4,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": ["jasmine"]
+    "types": ["jasmine"],
+    "resolveJsonModule": true
   },
   "files": ["src/test.ts", "src/polyfills.ts"],
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
- Follows #39
- See also #36 for more context

This should make the page tests more reliable by adding an initial router navigation, and fixes two issues that were non-deterministic failures before:

- Remove component declarations from test modules. (These conflict with the code under test, and cause the tests to fail once the code under test is fully loaded.)
- Add import for Transloco, required by the landing page