### PR TITLE
feat(web-client): add API schema and service

### DIFF
--- a/web-client/.eslintrc.json
+++ b/web-client/.eslintrc.json
@@ -36,6 +36,25 @@
             "prefix": "app",
             "style": "camelCase"
           }
+        ],
+        "@typescript-eslint/naming-convention": [
+          "error",
+          {
+            "selector": "default",
+            "format": ["camelCase", "snake_case"]
+          },
+          {
+            "selector": "variable",
+            "format": ["camelCase", "snake_case", "UPPER_CASE"]
+          },
+          {
+            "selector": "typeLike",
+            "format": ["PascalCase"]
+          },
+          {
+            "selector": "property",
+            "format": ["camelCase", "snake_case", "PascalCase"]
+          }
         ]
       }
     },

--- a/web-client/angular.json
+++ b/web-client/angular.json
@@ -73,7 +73,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "app:build"
+            "browserTarget": "app:build",
+            "proxyConfig": "proxy.conf.json"
           },
           "configurations": {
             "production": {

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -76,6 +76,7 @@
         "@types/jasmine": "~3.6.0",
         "@types/jasminewd2": "~2.0.3",
         "@types/node": "^12.11.1",
+        "@types/superagent": "^4.1.12",
         "@typescript-eslint/eslint-plugin": "4.16.1",
         "@typescript-eslint/parser": "4.16.1",
         "@webcomponents/custom-elements": "^1.4.3",
@@ -12427,6 +12428,12 @@
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
+      "dev": true
+    },
     "node_modules/@types/cors": {
       "version": "2.8.12",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
@@ -12710,6 +12717,16 @@
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
       "dev": true
+    },
+    "node_modules/@types/superagent": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.12.tgz",
+      "integrity": "sha512-1GQvD6sySQPD6p9EopDFI3f5OogdICl1sU/2ij3Esobz/RtL9fWZZDPmsuv7eiy5ya+XNiPAxUcI3HIUTJa+3A==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/tapable": {
       "version": "1.0.8",
@@ -51630,6 +51647,12 @@
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
     },
+    "@types/cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
+      "dev": true
+    },
     "@types/cors": {
       "version": "2.8.12",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
@@ -51915,6 +51938,16 @@
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
       "dev": true
+    },
+    "@types/superagent": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.12.tgz",
+      "integrity": "sha512-1GQvD6sySQPD6p9EopDFI3f5OogdICl1sU/2ij3Esobz/RtL9fWZZDPmsuv7eiy5ya+XNiPAxUcI3HIUTJa+3A==",
+      "dev": true,
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
     },
     "@types/tapable": {
       "version": "1.0.8",

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -29,10 +29,12 @@
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "@ionic/angular": "^5.5.2",
         "@ionic/pwa-elements": "^3.0.2",
+        "@msgpack/msgpack": "^2.7.0",
         "@ngneat/transloco": "^2.22.0",
         "@zxing/browser": "^0.0.9",
         "@zxing/library": "^0.18.6",
         "@zxing/ngx-scanner": "^3.2.0",
+        "algosdk": "^1.11.0",
         "angularx-qrcode": "^11.0.0",
         "br-mask": "0.0.10",
         "ngx-printer": "^1.0.0",
@@ -40,6 +42,7 @@
         "sweetalert2": "^11.1.3",
         "tailwindcss-children": "^2.1.0",
         "tslib": "^2.0.0",
+        "tweetnacl": "^1.0.3",
         "zone.js": "~0.11.4"
       },
       "devDependencies": {
@@ -4610,6 +4613,14 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.7.0.tgz",
+      "integrity": "sha512-mlRYq9FSsOd4m+3wZWatemn3hGFZPWNJ4JQOdrir4rrMK2PyIk26idKBoUWrqF3HJJHl+5GpRU+M0wEruJwecg==",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@ngneat/transloco": {
       "version": "2.22.0",
@@ -13672,6 +13683,54 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/algo-msgpack-with-bigint": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/algo-msgpack-with-bigint/-/algo-msgpack-with-bigint-2.1.1.tgz",
+      "integrity": "sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/algosdk": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-1.11.1.tgz",
+      "integrity": "sha512-2B7Tz8NSaME1aQDrzvhAuTm67c/2KCXTeuzgKvB61YXUU3pe0zyDzEw7bgv1sC6lbbD6BihroiUtidP+Fdh+cQ==",
+      "dependencies": {
+        "algo-msgpack-with-bigint": "^2.1.1",
+        "buffer": "^6.0.2",
+        "hi-base32": "^0.5.1",
+        "js-sha256": "^0.9.0",
+        "js-sha3": "^0.8.0",
+        "js-sha512": "^0.8.0",
+        "json-bigint": "^1.0.0",
+        "superagent": "^6.1.0",
+        "tweetnacl": "^1.0.3",
+        "url-parse": "^1.5.1"
+      }
+    },
+    "node_modules/algosdk/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/alphanum-sort": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
@@ -14330,8 +14389,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -14752,7 +14810,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14810,6 +14867,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
@@ -14864,6 +14927,14 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
       "engines": {
         "node": "*"
       }
@@ -15543,7 +15614,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -16519,7 +16589,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -16564,8 +16633,7 @@
     "node_modules/component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-      "dev": true
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -16757,6 +16825,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "node_modules/copy-anything": {
       "version": "2.0.3",
@@ -18147,7 +18220,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -18515,7 +18587,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -20744,6 +20815,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
+      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
+    },
     "node_modules/fastq": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
@@ -21667,7 +21743,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -21684,6 +21759,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -21957,7 +22040,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -22408,7 +22490,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -22700,6 +22781,11 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
+    },
+    "node_modules/hi-base32": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
     },
     "node_modules/highlight.js": {
       "version": "10.7.3",
@@ -23304,7 +23390,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -25186,6 +25271,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
+    "node_modules/js-sha512": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
+    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -25241,6 +25341,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-parse-better-errors": {
@@ -26542,7 +26650,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -26967,7 +27074,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -27014,7 +27120,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
       "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
-      "dev": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -27026,7 +27131,6 @@
       "version": "1.48.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
       "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -27035,7 +27139,6 @@
       "version": "2.1.31",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
       "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.48.0"
       },
@@ -28788,7 +28891,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
       "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -33522,7 +33624,6 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
       "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
-      "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -33555,8 +33656,7 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -35003,8 +35103,7 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -36033,7 +36132,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -36440,7 +36538,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -37154,6 +37251,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sshpk/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "node_modules/ssri": {
       "version": "8.0.1",
@@ -37902,6 +38005,40 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": ">= 7.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/supports-color": {
@@ -38992,10 +39129,9 @@
       }
     },
     "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -39622,7 +39758,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
       "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
-      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -41846,8 +41981,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -45406,6 +45540,11 @@
           "dev": true
         }
       }
+    },
+    "@msgpack/msgpack": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.7.0.tgz",
+      "integrity": "sha512-mlRYq9FSsOd4m+3wZWatemn3hGFZPWNJ4JQOdrir4rrMK2PyIk26idKBoUWrqF3HJJHl+5GpRU+M0wEruJwecg=="
     },
     "@ngneat/transloco": {
       "version": "2.22.0",
@@ -52540,6 +52679,39 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true
     },
+    "algo-msgpack-with-bigint": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/algo-msgpack-with-bigint/-/algo-msgpack-with-bigint-2.1.1.tgz",
+      "integrity": "sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ=="
+    },
+    "algosdk": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-1.11.1.tgz",
+      "integrity": "sha512-2B7Tz8NSaME1aQDrzvhAuTm67c/2KCXTeuzgKvB61YXUU3pe0zyDzEw7bgv1sC6lbbD6BihroiUtidP+Fdh+cQ==",
+      "requires": {
+        "algo-msgpack-with-bigint": "^2.1.1",
+        "buffer": "^6.0.2",
+        "hi-base32": "^0.5.1",
+        "js-sha256": "^0.9.0",
+        "js-sha3": "^0.8.0",
+        "js-sha512": "^0.8.0",
+        "json-bigint": "^1.0.0",
+        "superagent": "^6.1.0",
+        "tweetnacl": "^1.0.3",
+        "url-parse": "^1.5.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
+      }
+    },
     "alphanum-sort": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
@@ -53050,8 +53222,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -53392,8 +53563,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "base64id": {
       "version": "2.0.0",
@@ -53429,6 +53599,14 @@
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true
+        }
       }
     },
     "bcryptjs": {
@@ -53475,6 +53653,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
+    },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -54055,7 +54238,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -54826,7 +55008,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -54858,8 +55039,7 @@
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-      "dev": true
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "compressible": {
       "version": "2.0.18",
@@ -55028,6 +55208,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-anything": {
       "version": "2.0.3",
@@ -56101,7 +56286,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -56387,8 +56571,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -58203,6 +58386,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
+      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
+    },
     "fastq": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
@@ -58946,7 +59134,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -58958,6 +59145,11 @@
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
       "dev": true
+    },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "forwarded": {
       "version": "0.2.0",
@@ -59170,7 +59362,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -59519,8 +59710,7 @@
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -59751,6 +59941,11 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
+    },
+    "hi-base32": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
     },
     "highlight.js": {
       "version": "10.7.3",
@@ -60247,8 +60442,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -61657,6 +61851,21 @@
         }
       }
     },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
+    "js-sha512": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -61695,6 +61904,14 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
+    },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -62739,7 +62956,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -63070,8 +63286,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "microevent.ts": {
       "version": "0.1.1",
@@ -63110,20 +63325,17 @@
     "mime": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
-      "dev": true
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
     },
     "mime-db": {
       "version": "1.48.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
-      "dev": true
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
     },
     "mime-types": {
       "version": "2.1.31",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
       "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-      "dev": true,
       "requires": {
         "mime-db": "1.48.0"
       }
@@ -64539,8 +64751,7 @@
     "object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "dev": true
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
     },
     "object-is": {
       "version": "1.1.5",
@@ -68071,7 +68282,6 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
       "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
-      "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -68091,8 +68301,7 @@
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -69228,8 +69437,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.20.0",
@@ -70030,7 +70238,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -70384,7 +70591,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -70989,6 +71195,14 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true
+        }
       }
     },
     "ssri": {
@@ -71580,6 +71794,36 @@
         "fast-glob": "^3.2.5",
         "klona": "^2.0.4",
         "normalize-path": "^3.0.0"
+      }
+    },
+    "superagent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "supports-color": {
@@ -72425,10 +72669,9 @@
       }
     },
     "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "type": {
       "version": "1.2.0",
@@ -72913,7 +73156,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
       "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
-      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -74663,8 +74905,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -46,10 +46,12 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@ionic/angular": "^5.5.2",
     "@ionic/pwa-elements": "^3.0.2",
+    "@msgpack/msgpack": "^2.7.0",
     "@ngneat/transloco": "^2.22.0",
     "@zxing/browser": "^0.0.9",
     "@zxing/library": "^0.18.6",
     "@zxing/ngx-scanner": "^3.2.0",
+    "algosdk": "^1.11.0",
     "angularx-qrcode": "^11.0.0",
     "br-mask": "0.0.10",
     "ngx-printer": "^1.0.0",
@@ -57,6 +59,7 @@
     "sweetalert2": "^11.1.3",
     "tailwindcss-children": "^2.1.0",
     "tslib": "^2.0.0",
+    "tweetnacl": "^1.0.3",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -93,6 +93,7 @@
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",
+    "@types/superagent": "^4.1.12",
     "@typescript-eslint/eslint-plugin": "4.16.1",
     "@typescript-eslint/parser": "4.16.1",
     "@webcomponents/custom-elements": "^1.4.3",

--- a/web-client/proxy.conf.json
+++ b/web-client/proxy.conf.json
@@ -1,0 +1,20 @@
+{
+  "/api/nautilus": {
+    "target": "http://ntls-demo.registree.io/",
+    "secure": false,
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/api/nautilus": ""
+    },
+    "logLevel": "debug"
+  },
+  "/api/algorand": {
+    "target": "https://testnet-algorand.api.purestake.io/ps2",
+    "secure": true,
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/api/algorand": ""
+    },
+    "logLevel": "debug"
+  }
+}

--- a/web-client/src/app/services/algosdk.utils.ts
+++ b/web-client/src/app/services/algosdk.utils.ts
@@ -1,0 +1,103 @@
+/**
+ * Supporting code from the algosdk examples / utils.
+ */
+
+import { Algodv2, EncodedSignedTransaction } from 'algosdk';
+
+export type TransactionConfirmation = {
+  txn: EncodedSignedTransaction;
+  confirmedRound: number;
+};
+
+/** Subset of algosdk's PendingTransactionResponse, without bigint. */
+type PendingInfo = {
+  poolError: string;
+  txn: EncodedSignedTransaction;
+  confirmedRound?: number;
+};
+
+/**
+ * Wait for a transaction to be confirmed.
+ *
+ * This is a cleaned-up version of:
+ * https://github.com/algorand/js-algorand-sdk/blob/v1.11.1/examples/utils.js#L67
+ */
+export const waitForConfirmation = async (
+  algodClient: Algodv2,
+  txId: string,
+  timeoutRounds: number
+): Promise<TransactionConfirmation> => {
+  const lastRound = await getLastRound(algodClient);
+
+  const startRound = lastRound + 1;
+  const endRound = startRound + timeoutRounds;
+  for (let nextRound = startRound; nextRound < endRound; nextRound++) {
+    // TODO: This throws a 404 error for txId not found: handle / report that better.
+    const pendingInfo = await getPendingInfo(algodClient, txId);
+    const { poolError, txn, confirmedRound } = pendingInfo;
+
+    if (confirmedRound && 0 < confirmedRound) {
+      // Transaction confirmed!
+      return { confirmedRound, txn };
+    } else if (poolError !== '') {
+      // TODO: Report rejections better.
+      throw new Error(
+        `Transaction ${txId} rejected - pool error: ${poolError}`
+      );
+    }
+
+    await algodClient.statusAfterBlock(nextRound).do();
+  }
+
+  // TODO: Handle timeouts better.
+  throw new Error(
+    `Transaction ${txId} not confirmed after ${timeoutRounds} rounds`
+  );
+};
+
+/** Helper: Get the node's last (most current) round. */
+const getLastRound = async (algodClient: Algodv2): Promise<number> => {
+  // Docs: https://developer.algorand.org/docs/reference/rest-apis/algod/v2/#get-v2status
+  // See also: algosdk NodeStatusResponse
+  const nodeStatus = await algodClient.status().do();
+  return checkNumber(nodeStatus['last-round']);
+};
+
+const getPendingInfo = async (
+  algodClient: Algodv2,
+  txId: string
+): Promise<PendingInfo> => {
+  // Docs: https://developer.algorand.org/docs/reference/rest-apis/algod/v2/#get-v2transactionspendingtxid
+  // See also: algosdk PendingTransactionResponse
+  const pendingInfo = await algodClient
+    .pendingTransactionInformation(txId)
+    .do();
+
+  const poolError = checkString(pendingInfo['pool-error']);
+  const txn = pendingInfo.txn;
+  const confirmedRound =
+    'confirmed-round' in pendingInfo
+      ? checkNumber(pendingInfo['confirmed-round'])
+      : undefined;
+
+  return { poolError, txn, confirmedRound };
+};
+
+const checkNumber = (value: unknown): number => {
+  if (typeof value === 'number') {
+    return value;
+  } else {
+    const message = `waitForConfirmation: expected number, got ${typeof value}`;
+    console.error(message, value);
+    throw new TypeError(`${message}: ${value}`);
+  }
+};
+const checkString = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  } else {
+    const message = `waitForConfirmation: expected string, got ${typeof value}`;
+    console.error(message, value);
+    throw new TypeError(`${message}: ${value}`);
+  }
+};

--- a/web-client/src/app/services/wallet.service.spec.ts
+++ b/web-client/src/app/services/wallet.service.spec.ts
@@ -1,0 +1,18 @@
+import { HttpClientModule } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { WalletService } from './wallet.service';
+
+describe('WalletService', () => {
+  let service: WalletService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientModule],
+    });
+    service = TestBed.inject(WalletService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/web-client/src/app/services/wallet.service.spec.ts
+++ b/web-client/src/app/services/wallet.service.spec.ts
@@ -1,5 +1,31 @@
-import { HttpClientModule } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { environment } from '../../environments/environment';
+import {
+  CreateWallet,
+  CreateWalletResult,
+  OpenWallet,
+  OpenWalletResult,
+  SignTransaction,
+  SignTransactionResult,
+  WalletRequest,
+  WalletResponse,
+} from '../../schema/actions';
+import { AttestationReport } from '../../schema/attestation';
+import { TweetNaClCrypto } from '../../schema/crypto';
+import { from_msgpack_as, to_msgpack_as } from '../../schema/msgpack';
+import {
+  SealedMessage,
+  seal_msgpack_as,
+  unseal_msgpack_as,
+} from '../../schema/sealing';
+import {
+  withNestedResolveContexts,
+  withResolveContext,
+} from '../../tests/test.helpers';
 import {
   arrayViewFromBuffer,
   bufferFromArrayView,
@@ -9,16 +35,308 @@ import {
 describe('WalletService', () => {
   let service: WalletService;
 
+  let httpTestingController: HttpTestingController;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientModule],
+      imports: [HttpClientTestingModule],
     });
     service = TestBed.inject(WalletService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('getEnclaveReport', async () => {
+    const stubReport = stubAttestationReport();
+
+    const report = await withResolveContext(
+      service.getEnclaveReport(),
+      stubbedEnclaveReport(httpTestingController, stubReport)
+    );
+
+    await expect(report).toEqual(stubReport);
+  });
+
+  it('getEnclavePublicKey', async () => {
+    const stubReport = stubAttestationReport();
+
+    const report = await withResolveContext(
+      service.getEnclavePublicKey(),
+      stubbedEnclaveReport(httpTestingController, stubReport)
+    );
+
+    await expect(report).toEqual(stubReport.enclave_public_key);
+  });
+
+  describe('createWallet', () => {
+    const requestCreate: CreateWallet = {
+      owner_name: 'Test Owner',
+      auth_pin: '1234',
+    };
+
+    it('Created', async () => {
+      const stubResultCreated: CreateWalletResult = {
+        Created: {
+          wallet_id: 'dummy wallet id',
+          owner_name: requestCreate.owner_name,
+          algorand_address_base32: 'dummy algorand address',
+        },
+      };
+      const result = await simulateWalletOperation(
+        httpTestingController,
+        service.createWallet(requestCreate),
+        { CreateWallet: requestCreate },
+        { CreateWallet: stubResultCreated }
+      );
+      await expect(result).toEqual(stubResultCreated);
+    });
+
+    it('Failed', async () => {
+      const stubResultFailed: CreateWalletResult = {
+        Failed: 'failed to create wallet',
+      };
+      const result = await simulateWalletOperation(
+        httpTestingController,
+        service.createWallet(requestCreate),
+        { CreateWallet: requestCreate },
+        { CreateWallet: stubResultFailed }
+      );
+      await expect(result).toEqual(stubResultFailed);
+    });
+  });
+
+  describe('openWallet', () => {
+    const requestOpen: OpenWallet = {
+      wallet_id: 'dummy wallet id',
+      auth_pin: '1234',
+    };
+
+    it('Opened', async () => {
+      const stubResultOpened: OpenWalletResult = {
+        Opened: {
+          wallet_id: 'dummy wallet id',
+          owner_name: 'dummy owner name',
+          algorand_address_base32: 'dummy algorand address',
+        },
+      };
+      const result = await simulateWalletOperation(
+        httpTestingController,
+        service.openWallet(requestOpen),
+        { OpenWallet: requestOpen },
+        { OpenWallet: stubResultOpened }
+      );
+      await expect(result).toEqual(stubResultOpened);
+    });
+
+    it('InvalidAuth', async () => {
+      const stubResultInvalidAuth: OpenWalletResult = {
+        InvalidAuth: null,
+      };
+      const result = await simulateWalletOperation(
+        httpTestingController,
+        service.openWallet(requestOpen),
+        { OpenWallet: requestOpen },
+        { OpenWallet: stubResultInvalidAuth }
+      );
+      await expect(result).toEqual(stubResultInvalidAuth);
+    });
+
+    it('Failed', async () => {
+      const stubResultFailed: OpenWalletResult = {
+        Failed: 'failed to open wallet',
+      };
+      const result = await simulateWalletOperation(
+        httpTestingController,
+        service.openWallet(requestOpen),
+        { OpenWallet: requestOpen },
+        { OpenWallet: stubResultFailed }
+      );
+      await expect(result).toEqual(stubResultFailed);
+    });
+  });
+
+  describe('signTransaction', () => {
+    const requestSign: SignTransaction = {
+      wallet_id: 'dummy wallet id',
+      auth_pin: '1234',
+      algorand_transaction_bytes: new TextEncoder().encode(
+        'dummy unsigned transaction'
+      ),
+    };
+
+    it('Signed', async () => {
+      const stubResultSigned: SignTransactionResult = {
+        Signed: {
+          signed_transaction_bytes: new TextEncoder().encode(
+            'dummy signed transaction'
+          ),
+        },
+      };
+      const result = await simulateWalletOperation(
+        httpTestingController,
+        service.signTransaction(requestSign),
+        { SignTransaction: requestSign },
+        { SignTransaction: stubResultSigned }
+      );
+      await expect(result).toEqual(stubResultSigned);
+    });
+
+    it('InvalidAuth', async () => {
+      const stubResultInvalidAuth: SignTransactionResult = {
+        InvalidAuth: null,
+      };
+      const result = await simulateWalletOperation(
+        httpTestingController,
+        service.signTransaction(requestSign),
+        { SignTransaction: requestSign },
+        { SignTransaction: stubResultInvalidAuth }
+      );
+      await expect(result).toEqual(stubResultInvalidAuth);
+    });
+
+    it('Failed', async () => {
+      const stubResultFailed: SignTransactionResult = {
+        Failed: 'failed to open wallet',
+      };
+      const result = await simulateWalletOperation(
+        httpTestingController,
+        service.signTransaction(requestSign),
+        { SignTransaction: requestSign },
+        { SignTransaction: stubResultFailed }
+      );
+      await expect(result).toEqual(stubResultFailed);
+    });
+  });
+});
+
+/**
+ * Simulate a sealed wallet operation exchange.
+ *
+ * This expects the operation to call the `enclave-report` and `wallet-operation` endpoints in sequence.
+ *
+ * @param httpTestingController (from Angular)
+ * @param walletOperation Promise for the initiated wallet operation
+ * @param expectedWalletRequest The unsealed wallet operation request to expect
+ * @param stubWalletResponse The unsealed wallet operation response to seal and return
+ */
+const simulateWalletOperation = async <R>(
+  httpTestingController: HttpTestingController,
+  walletOperation: Promise<R>,
+  expectedWalletRequest: WalletRequest,
+  stubWalletResponse: WalletResponse
+): Promise<R> => {
+  const simulatedEnclaveCrypto = TweetNaClCrypto.new();
+  const stubReport = stubAttestationReport(simulatedEnclaveCrypto.public_key);
+  return await withNestedResolveContexts(walletOperation, [
+    stubbedEnclaveReport(httpTestingController, stubReport),
+    stubbedWalletOperation(
+      httpTestingController,
+      simulatedEnclaveCrypto,
+      expectedWalletRequest,
+      stubWalletResponse
+    ),
+  ]);
+};
+
+/**
+ * Return a callable that stubs the `enclave-report` endpoint
+ *
+ * @param httpTestingController (from Angular)
+ * @param stubReport The enclave report to return
+ */
+const stubbedEnclaveReport =
+  (
+    httpTestingController: HttpTestingController,
+    stubReport: AttestationReport
+  ): (() => void) =>
+  () => {
+    const url = new URL(
+      'enclave-report',
+      environment.nautilusWalletServer
+    ).toString();
+
+    const stubReportBytes = to_msgpack_as<AttestationReport>(stubReport);
+    const stubReportBuffer = bufferFromArrayView(stubReportBytes);
+
+    httpTestingController
+      .expectOne({ method: 'GET', url })
+      .flush(stubReportBuffer);
+  };
+
+/**
+ * Return a callable that stubs a sealed `wallet-operation` exchange.
+ *
+ * @param httpTestingController (from Angular)
+ * @param simulatedEnclaveCrypto The crypto instance to simulate the enclave's message sealing with
+ * @param expectedWalletRequest The unsealed wallet operation request to expect
+ * @param stubWalletResponse The unsealed wallet operation response to seal and return
+ */
+const stubbedWalletOperation =
+  (
+    httpTestingController: HttpTestingController,
+    simulatedEnclaveCrypto: TweetNaClCrypto,
+    expectedWalletRequest: WalletRequest,
+    stubWalletResponse: WalletResponse
+  ): (() => void) =>
+  () => {
+    const url = new URL(
+      'wallet-operation',
+      environment.nautilusWalletServer
+    ).toString();
+
+    const httpRequest = httpTestingController.expectOne({
+      method: 'POST',
+      url,
+    });
+    const sealedMessageBytes = arrayViewFromBuffer(httpRequest.request.body);
+    const walletRequest: WalletRequest | null = unseal_msgpack_as(
+      sealedMessageBytes,
+      simulatedEnclaveCrypto
+    );
+    expect(walletRequest).not.toBeNull();
+    expect(walletRequest).toEqual(expectedWalletRequest);
+
+    const { sender_public_key } =
+      from_msgpack_as<SealedMessage>(sealedMessageBytes);
+    const stubResultBytes = seal_msgpack_as<WalletResponse>(
+      stubWalletResponse,
+      sender_public_key,
+      simulatedEnclaveCrypto
+    );
+    const stubResultBuffer = bufferFromArrayView(stubResultBytes);
+    httpRequest.flush(stubResultBuffer);
+  };
+
+/** Construct a stub AttestationReport value. */
+const stubAttestationReport = (
+  enclavePublicKey: Uint8Array = new Uint8Array(32)
+): AttestationReport => ({
+  enclave_public_key: enclavePublicKey,
+  report: {
+    body: {
+      cpu_svn: new Uint8Array(16),
+      isv_ext_prod_id: new Uint8Array(16),
+      attributes_flags: 0,
+      attributes_xfrm: 0,
+      mr_enclave: new Uint8Array(32),
+      mr_signer: new Uint8Array(32),
+      config_id: new Uint8Array(16),
+      isv_prod_id: 0,
+      isv_svn: 0,
+      config_svn: 0,
+      isv_family_id: new Uint8Array(16),
+      report_data: new Uint8Array(64),
+    },
+    key_id: new Uint8Array(32),
+    mac: new Uint8Array(16),
+  },
 });
 
 describe('WalletService array helpers', () => {

--- a/web-client/src/app/services/wallet.service.spec.ts
+++ b/web-client/src/app/services/wallet.service.spec.ts
@@ -1,6 +1,10 @@
 import { HttpClientModule } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
-import { WalletService } from './wallet.service';
+import {
+  arrayViewFromBuffer,
+  bufferFromArrayView,
+  WalletService,
+} from './wallet.service';
 
 describe('WalletService', () => {
   let service: WalletService;
@@ -14,5 +18,91 @@ describe('WalletService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+});
+
+describe('WalletService array helpers', () => {
+  const nonArrayExamples: Array<[string, unknown]> = [
+    ['undefined', undefined],
+    ['null', null],
+    ['false', false],
+    ['true', false],
+    ['zero', 0],
+    ['empty string', ''],
+    ['[]]', []],
+    ['{}}', {}],
+    ['number', 42],
+    ['string', 'spam'],
+    ['Array', [1, 2, 3]],
+    ['Object', { ham: 'spam' }],
+  ];
+
+  describe('arrayViewFromBuffer', () => {
+    describe('converts ArrayBuffer', () => {
+      for (const [label, buffer, expected] of [
+        ['empty', new ArrayBuffer(0), new Uint8Array()],
+        ['zeroes', new ArrayBuffer(5), new Uint8Array(5)],
+        ['values', new Uint8Array([1, 2, 3]).buffer, new Uint8Array([1, 2, 3])],
+      ] as Array<[string, ArrayBuffer, Uint8Array]>) {
+        it(label, () => {
+          expect(arrayViewFromBuffer(buffer)).toEqual(expected);
+        });
+      }
+    });
+
+    describe('rejects other types', () => {
+      for (const [label, value] of [
+        ...nonArrayExamples,
+        ['Uint8Array', new Uint8Array()],
+        ['Uint8Array(5)', new Uint8Array(5)],
+      ] as Array<[string, unknown]>) {
+        it(label, () => {
+          expect(() => arrayViewFromBuffer(value as ArrayBuffer)).toThrowError(
+            TypeError,
+            'expected ArrayBuffer'
+          );
+        });
+      }
+    });
+  });
+
+  describe('bufferFromArrayView', () => {
+    describe('converts Uint8Array', () => {
+      for (const [label, array, expected] of [
+        ['empty', new Uint8Array(), new ArrayBuffer(0)],
+        ['zeroes', new Uint8Array(5), new ArrayBuffer(5)],
+        ['values', new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]).buffer],
+        // XXX: The following case is important.
+        [
+          'sliced view',
+          new Uint8Array(new Uint8Array([1, 2, 3, 4, 5]).buffer, 1, 3),
+          new Uint8Array([2, 3, 4]).buffer,
+        ],
+      ] as Array<[string, Uint8Array, ArrayBuffer]>) {
+        it(label, () => {
+          // XXX: Unlike Uint8Array, ArrayBuffers can't be directly compared with toEqual.
+          //      Instead, we compare the buffers by comparing their full (unsliced) Uint8Array views.
+          const actual = bufferFromArrayView(array);
+          expect(new Uint8Array(actual)).toEqual(new Uint8Array(expected));
+        });
+      }
+    });
+
+    describe('rejects other types', () => {
+      for (const [label, value] of [
+        ...nonArrayExamples,
+        ['ArrayBuffer', new ArrayBuffer(0)],
+        ['ArrayBuffer(5)', new ArrayBuffer(5)],
+        ['Int8Array', new Int8Array()],
+        ['Uint16Array', new Uint16Array()],
+      ] as Array<[string, unknown]>) {
+        it(label, () => {
+          expect(() => bufferFromArrayView(value as Uint8Array)).toThrowError(
+            TypeError,
+            'expected Uint8Array'
+          );
+        });
+      }
+    });
   });
 });

--- a/web-client/src/app/services/wallet.service.ts
+++ b/web-client/src/app/services/wallet.service.ts
@@ -1,0 +1,187 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import algosdk from 'algosdk';
+import { environment } from 'src/environments/environment';
+import {
+  CreateWallet,
+  CreateWalletResult,
+  OpenWallet,
+  OpenWalletResult,
+  SignTransaction,
+  SignTransactionResult,
+} from '../../schema/actions';
+import {
+  makePaymentTxnHelper,
+  OptionalParameters,
+  RequiredParameters,
+} from '../../schema/algorand.helpers';
+import { AttestationReport } from '../../schema/attestation';
+import { PublicKey, TweetNaClCrypto } from '../../schema/crypto';
+import { from_msgpack_as } from '../../schema/msgpack';
+import { seal_msgpack_as, unseal_msgpack_as } from '../../schema/sealing';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class WalletService {
+  constructor(private http: HttpClient) {}
+
+  async getEnclaveReport(): Promise<AttestationReport> {
+    const bytes = await this.walletApiGetBytes('enclave-report');
+    return from_msgpack_as<AttestationReport>(bytes);
+  }
+
+  async getEnclavePublicKey(): Promise<PublicKey> {
+    const report: AttestationReport = await this.getEnclaveReport();
+    // XXX: msgpack returns Array<number>: coerce to Uint8Array for tweetnacl
+    return new Uint8Array(report.enclave_public_key);
+  }
+
+  async createWallet(request: CreateWallet): Promise<CreateWalletResult> {
+    const walletRequest = { CreateWallet: request };
+    const response = await this.postSealedExchange<
+      { CreateWallet: CreateWallet },
+      { CreateWallet: CreateWalletResult }
+    >(walletRequest);
+    const { CreateWallet: result } = response;
+    return result;
+  }
+
+  async openWallet(request: OpenWallet): Promise<OpenWalletResult> {
+    const walletRequest = { OpenWallet: request };
+    const response = await this.postSealedExchange<
+      { OpenWallet: OpenWallet },
+      { OpenWallet: OpenWalletResult }
+    >(walletRequest);
+    const { OpenWallet: result } = response;
+    return result;
+  }
+
+  async signTransaction(
+    request: SignTransaction
+  ): Promise<SignTransactionResult> {
+    const walletRequest = { SignTransaction: request };
+    const response = await this.postSealedExchange<
+      { SignTransaction: SignTransaction },
+      { SignTransaction: SignTransactionResult }
+    >(walletRequest);
+    const { SignTransaction: result } = response;
+    return result;
+  }
+
+  // Algorand network interface functions:
+
+  async createUnsignedTransaction(
+    required: RequiredParameters,
+    optional?: OptionalParameters
+  ) {
+    const algodClient = this.getAlgodClient();
+    const suggestedParams = await algodClient.getTransactionParams().do();
+    console.log('createUnsignedTransaction', 'got:', { suggestedParams });
+    const transaction = makePaymentTxnHelper(
+      suggestedParams,
+      required,
+      optional
+    );
+    console.log('createUnsignedTransaction', 'created:', { transaction });
+    return transaction;
+  }
+
+  async submitSignedTransaction(
+    signedTxn: Uint8Array
+  ): Promise<{ txId: string }> {
+    return await this.getAlgodClient().sendRawTransaction(signedTxn).do();
+  }
+
+  // HTTP helpers
+
+  protected async walletApiGetBytes(path: string): Promise<Uint8Array> {
+    const url = this.getWalletApiUrl(path);
+    const arrayBuffer = await this.http
+      .get(url, { responseType: 'arraybuffer' })
+      .toPromise();
+    return arrayViewFromBuffer(arrayBuffer);
+  }
+
+  protected async walletApiPostBytes(
+    path: string,
+    bytes: Uint8Array
+  ): Promise<Uint8Array> {
+    const url = this.getWalletApiUrl(path);
+    const body = bufferFromArrayView(bytes);
+    const arrayBuffer = await this.http
+      .post(url, body, { responseType: 'arraybuffer' })
+      .toPromise();
+    return arrayViewFromBuffer(arrayBuffer);
+  }
+
+  protected async postSealedExchange<Request, Response>(
+    request: Request
+  ): Promise<Response> {
+    const clientCrypto = TweetNaClCrypto.new();
+
+    const enclavePublicKey = await this.getEnclavePublicKey();
+
+    const sealedRequestBytes = seal_msgpack_as<Request>(
+      request,
+      enclavePublicKey,
+      clientCrypto
+    );
+    const sealedResponseBytes = await this.walletApiPostBytes(
+      'wallet-operation',
+      sealedRequestBytes
+    );
+    const response = unseal_msgpack_as<Response>(
+      sealedResponseBytes,
+      clientCrypto
+    );
+    if (response !== null) {
+      return response;
+    } else {
+      console.error('XXX unsealing failed:', { sealedResponseBytes });
+      throw new Error('unsealing response failed!');
+    }
+  }
+
+  // Configuration helpers:
+
+  protected getWalletApiUrl(path: string): string {
+    const nautilusBaseUrl = environment.nautilusWalletServer;
+    if (nautilusBaseUrl === undefined) {
+      throw new Error('environment.algod.token not configured');
+    }
+    return new URL(path, nautilusBaseUrl).toString();
+  }
+
+  protected getAlgodClient() {
+    const algod = environment.algod;
+    if (algod.token === undefined) {
+      throw new Error('environment.algod.token not configured');
+    }
+    return new algosdk.Algodv2(algod.token, algod.baseServer, algod.port);
+  }
+}
+
+// Convert bytes between typed array views and buffers.
+//
+// Note that these types are similar and closely related, but not interchangeable:
+// code that expects an ArrayBuffer may fail if given a Uint8Array, and vice versa.
+//
+// Also, note that TypeScript's type system does not actually distinguish these two,
+// so this code checks the types at run-time to avoid hard-to-diagnose errors.
+
+const arrayViewFromBuffer = (buffer: ArrayBuffer): Uint8Array => {
+  if (!(buffer instanceof ArrayBuffer)) {
+    throw new TypeError(`expected ArrayBuffer`);
+  }
+  return new Uint8Array(buffer);
+};
+
+const bufferFromArrayView = (view: Uint8Array): ArrayBuffer => {
+  if (!(view instanceof Uint8Array)) {
+    throw new TypeError(`expected Uint8Array`);
+  }
+  const begin = view.byteOffset;
+  const end = view.byteOffset + view.byteLength;
+  return view.buffer.slice(begin, end);
+};

--- a/web-client/src/app/services/wallet.service.ts
+++ b/web-client/src/app/services/wallet.service.ts
@@ -186,16 +186,16 @@ export class WalletService {
 // Also, note that TypeScript's type system does not actually distinguish these two,
 // so this code checks the types at run-time to avoid hard-to-diagnose errors.
 
-const arrayViewFromBuffer = (buffer: ArrayBuffer): Uint8Array => {
+export const arrayViewFromBuffer = (buffer: ArrayBuffer): Uint8Array => {
   if (!(buffer instanceof ArrayBuffer)) {
-    throw new TypeError(`expected ArrayBuffer`);
+    throw new TypeError('expected ArrayBuffer');
   }
   return new Uint8Array(buffer);
 };
 
-const bufferFromArrayView = (view: Uint8Array): ArrayBuffer => {
+export const bufferFromArrayView = (view: Uint8Array): ArrayBuffer => {
   if (!(view instanceof Uint8Array)) {
-    throw new TypeError(`expected Uint8Array`);
+    throw new TypeError('expected Uint8Array');
   }
   const begin = view.byteOffset;
   const end = view.byteOffset + view.byteLength;

--- a/web-client/src/app/services/wallet.service.ts
+++ b/web-client/src/app/services/wallet.service.ts
@@ -19,6 +19,7 @@ import { AttestationReport } from '../../schema/attestation';
 import { PublicKey, TweetNaClCrypto } from '../../schema/crypto';
 import { from_msgpack_as } from '../../schema/msgpack';
 import { seal_msgpack_as, unseal_msgpack_as } from '../../schema/sealing';
+import { TransactionConfirmation, waitForConfirmation } from './algosdk.utils';
 
 @Injectable({
   providedIn: 'root',
@@ -91,6 +92,21 @@ export class WalletService {
     signedTxn: Uint8Array
   ): Promise<{ txId: string }> {
     return await this.getAlgodClient().sendRawTransaction(signedTxn).do();
+  }
+
+  async waitForTransactionConfirmation(
+    txId: string
+  ): Promise<TransactionConfirmation> {
+    // TODO: Report rejection and timeout in a way the UI can use.
+    return waitForConfirmation(this.getAlgodClient(), txId, 4);
+  }
+
+  /** Combine {@link submitSignedTransaction} and {@link waitForTransactionConfirmation}. */
+  async submitAndConfirmTransaction(
+    signedTxn: Uint8Array
+  ): Promise<TransactionConfirmation> {
+    const { txId } = await this.submitSignedTransaction(signedTxn);
+    return await this.waitForTransactionConfirmation(txId);
   }
 
   // HTTP helpers

--- a/web-client/src/environments/environment.prod.ts
+++ b/web-client/src/environments/environment.prod.ts
@@ -1,3 +1,11 @@
 export const environment = {
   production: true,
+  // TODO: Production endpoint
+  nautilusWalletServer: 'http://ntls-demo.registree.io/',
+  algod: {
+    baseServer: 'https://testnet-algorand.api.purestake.io/ps2',
+    port: '',
+    // FIXME: Development key
+    token: { 'X-API-Key': 'J7eo2jPb5m4OiBneIV6r0ajgRLeSaHqk3QplGETk' },
+  },
 };

--- a/web-client/src/environments/environment.ts
+++ b/web-client/src/environments/environment.ts
@@ -4,6 +4,16 @@
 
 export const environment = {
   production: false,
+  nautilusWalletServer: 'http://localhost:4200/api/nautilus/', // trailing slash matters
+  // See `proxyConfig` in `angular.json`, and `proxy.conf.json`
+  // Docs: https://angular.io/guide/build#proxying-to-a-backend-server
+  algod: {
+    // XXX: Algodv2's parameter handling is a bit weird: the HTTP port must be passed separately.
+    baseServer: 'http://localhost/api/algorand',
+    port: 4200,
+    // FIXME: Development key
+    token: { 'X-API-Key': 'J7eo2jPb5m4OiBneIV6r0ajgRLeSaHqk3QplGETk' },
+  },
 };
 
 /*

--- a/web-client/src/schema/actions.ts
+++ b/web-client/src/schema/actions.ts
@@ -1,0 +1,46 @@
+/** Core request / response message types. */
+
+import { AlgorandTransactionSigned, WalletDisplay } from './entities';
+import { Bytes, WalletId, WalletPin } from './types';
+
+export type CreateWallet = {
+  owner_name: string;
+  auth_pin: WalletPin;
+};
+
+export type CreateWalletResult =
+  | { Created: WalletDisplay }
+  | { Failed: string };
+
+export type OpenWallet = {
+  wallet_id: WalletId;
+  auth_pin: WalletPin;
+};
+
+export type OpenWalletResult =
+  | { Opened: WalletDisplay }
+  | { InvalidAuth: null }
+  | { Failed: string };
+
+export type SignTransaction = {
+  wallet_id: WalletId;
+  auth_pin: WalletPin;
+  algorand_transaction_bytes: Bytes;
+};
+
+export type SignTransactionResult =
+  | { Signed: AlgorandTransactionSigned }
+  | { InvalidAuth: null }
+  | { Failed: string };
+
+/** Dispatching enum for action requests. */
+export type WalletRequest =
+  | { CreateWallet: CreateWallet }
+  | { OpenWallet: OpenWallet }
+  | { SignTransaction: SignTransaction };
+
+/** Dispatching enum for action results. */
+export type WalletResponse =
+  | { CreateWallet: CreateWalletResult }
+  | { OpenWallet: OpenWalletResult }
+  | { SignTransaction: SignTransactionResult };

--- a/web-client/src/schema/algorand.helpers.spec.ts
+++ b/web-client/src/schema/algorand.helpers.spec.ts
@@ -1,0 +1,69 @@
+import { SuggestedParams, Transaction } from 'algosdk';
+import { makePaymentTxnHelper, OptionalParameters } from './algorand.helpers';
+
+describe('makePaymentTxnHelper', () => {
+  const suggested: SuggestedParams = {
+    fee: 1_000,
+    firstRound: 10_000,
+    lastRound: 11_000,
+    genesisID: 'dummy genesis ID',
+    genesisHash: 'dummy genesis hash',
+  };
+  const dummyAddress =
+    'VCMJKWOY5P5P7SKMZFFOCEROPJCZOTIJMNIYNUCKH7LRO45JMJP6UYBIJA';
+  const required = {
+    from: dummyAddress,
+    to: dummyAddress,
+    amount: 123,
+  };
+
+  it('with required only', () => {
+    expect(makePaymentTxnHelper(suggested, required)).toEqual(
+      new Transaction({ ...suggested, ...required })
+    );
+  });
+
+  it('with no-effect optional', () => {
+    for (const optional of [
+      undefined,
+      {},
+      { options: {} },
+      { modifySuggested: (params) => params },
+      { options: {}, modifySuggested: (params) => params },
+    ] as Array<OptionalParameters>) {
+      expect(makePaymentTxnHelper(suggested, required, optional)).toEqual(
+        new Transaction({ ...suggested, ...required })
+      );
+    }
+  });
+
+  it('with options', () => {
+    const note = new TextEncoder().encode('test note');
+    expect(
+      makePaymentTxnHelper(suggested, required, { options: { note } })
+    ).toEqual(
+      new Transaction({
+        ...suggested,
+        ...required,
+        note,
+      })
+    );
+  });
+
+  it('with modifySuggested', () => {
+    expect(
+      makePaymentTxnHelper(suggested, required, {
+        modifySuggested: (params) => ({
+          ...params,
+          lastRound: params.firstRound + 4,
+        }),
+      })
+    ).toEqual(
+      new Transaction({
+        ...suggested,
+        ...required,
+        lastRound: suggested.firstRound + 4,
+      })
+    );
+  });
+});

--- a/web-client/src/schema/algorand.helpers.ts
+++ b/web-client/src/schema/algorand.helpers.ts
@@ -1,0 +1,31 @@
+import algosdk, { SuggestedParams, Transaction } from 'algosdk';
+import { PaymentTxn } from 'algosdk/dist/types/src/types/transactions';
+import { RenameProperty } from 'algosdk/dist/types/src/types/utils';
+
+export type RequiredParameters = Pick<PaymentTxn, 'from' | 'to' | 'amount'>;
+
+export type OptionalParameters = {
+  options?: OptionParameters;
+  modifySuggested?: (suggested: SuggestedParams) => SuggestedParams;
+};
+
+export type OptionParameters = RenameProperty<
+  Pick<PaymentTxn, 'closeRemainderTo' | 'note' | 'reKeyTo'>,
+  'reKeyTo',
+  'rekeyTo'
+>;
+
+/** Wrap `makePaymentTxnWithSuggestedParamsFromObject` with more convenient argument handling. */
+export const makePaymentTxnHelper = (
+  suggested: SuggestedParams,
+  required: RequiredParameters,
+  optional?: OptionalParameters
+): Transaction => {
+  const unmodified = <O>(o: O): O => o;
+  const suggestedParams = (optional?.modifySuggested ?? unmodified)(suggested);
+  return algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+    suggestedParams,
+    ...optional?.options,
+    ...required,
+  });
+};

--- a/web-client/src/schema/attestation.ts
+++ b/web-client/src/schema/attestation.ts
@@ -1,0 +1,28 @@
+import { PublicKey } from './crypto';
+import { Bytes } from './types';
+
+export type AttestationReport = {
+  report: SgxReport;
+  enclave_public_key: PublicKey;
+};
+
+export type SgxReport = {
+  body: SgxReportBody;
+  key_id: Bytes;
+  mac: Bytes;
+};
+
+export type SgxReportBody = {
+  cpu_svn: Bytes;
+  isv_ext_prod_id: Bytes;
+  attributes_flags: number;
+  attributes_xfrm: number;
+  mr_enclave: Bytes;
+  mr_signer: Bytes;
+  config_id: Bytes;
+  isv_prod_id: number;
+  isv_svn: number;
+  config_svn: number;
+  isv_family_id: Bytes;
+  report_data: Bytes;
+};

--- a/web-client/src/schema/crypto.ts
+++ b/web-client/src/schema/crypto.ts
@@ -1,0 +1,43 @@
+/**
+ * Interface patterned after `SodaBoxCrypto` on the server, but implemented using TweetNaCl.
+ */
+
+import * as nacl from 'tweetnacl';
+import { BoxKeyPair } from 'tweetnacl';
+import { Bytes, Bytes24, Bytes32 } from './types';
+
+export type PublicKey = Bytes32;
+export type PrivateKey = Bytes32;
+export type Nonce = Bytes24;
+
+type EncryptedMessage = {
+  ciphertext: Bytes;
+  nonce: Bytes24;
+};
+
+export class TweetNaClCrypto {
+  constructor(public keyPair: BoxKeyPair) {}
+
+  static new = (): TweetNaClCrypto => new TweetNaClCrypto(nacl.box.keyPair());
+
+  get public_key(): PublicKey {
+    return this.keyPair.publicKey;
+  }
+
+  get secret_key(): PrivateKey {
+    return this.keyPair.secretKey;
+  }
+
+  decrypt_message = (
+    ciphertext: Bytes,
+    their_pk: PublicKey,
+    nonce: Nonce
+  ): Uint8Array | null =>
+    nacl.box.open(ciphertext, nonce, their_pk, this.secret_key);
+
+  encrypt_message = (message: Bytes, their_pk: PublicKey): EncryptedMessage => {
+    const nonce = nacl.randomBytes(nacl.box.nonceLength);
+    const ciphertext = nacl.box(message, nonce, their_pk, this.secret_key);
+    return { ciphertext, nonce };
+  };
+}

--- a/web-client/src/schema/entities.ts
+++ b/web-client/src/schema/entities.ts
@@ -1,0 +1,30 @@
+/** Structures representing various entities. */
+
+import {
+  AlgorandAccountSeedBytes,
+  AlgorandAddressBase32,
+  Bytes,
+  WalletId,
+} from './types';
+
+/** A Nautilus wallet's basic displayable details. */
+export type WalletDisplay = {
+  wallet_id: WalletId;
+  owner_name: string;
+  algorand_address_base32: AlgorandAddressBase32;
+};
+
+/** An Algorand account. */
+export type AlgorandAccount = {
+  seed_bytes: AlgorandAccountSeedBytes;
+};
+
+/** An unsigned Algorand transaction.*/
+export type AlgorandTransaction = {
+  transaction_bytes: Bytes;
+};
+
+/** An signed Algorand transaction.*/
+export type AlgorandTransactionSigned = {
+  signed_transaction_bytes: Bytes;
+};

--- a/web-client/src/schema/msgpack.ts
+++ b/web-client/src/schema/msgpack.ts
@@ -1,0 +1,47 @@
+/** MessagePack helper functions. */
+
+import { Decoder, Encoder } from '@msgpack/msgpack';
+import { Bytes } from './types';
+
+/// Enable for verbose from_msgpack / to_msgpack console debugging logs.
+const LOG_DEBUG = false;
+
+const encoder = new Encoder();
+const decoder = new Decoder();
+
+// TODO: Better type handling.
+
+export const from_msgpack = (bytes: Bytes): unknown => {
+  const value = decoder.decode(bytes);
+  log_debug('from_msgpack', { value, bytes });
+  return value;
+};
+
+export const to_msgpack = (value: unknown): Bytes => {
+  const bytes = encoder.encode(value);
+  log_debug('to_msgpack', { value, bytes });
+  return bytes;
+};
+
+const log_debug = (
+  label: string,
+  { value, bytes }: { value: unknown; bytes: Bytes }
+) => {
+  if (LOG_DEBUG) {
+    // eslint-disable-next-line no-console
+    console.debug(label, {
+      value,
+      bytes: base64(bytes),
+    });
+  }
+};
+
+// FIXME: Placeholder casts
+
+export const from_msgpack_as = <T>(bytes: Bytes): T => from_msgpack(bytes) as T;
+
+export const to_msgpack_as = <T>(value: T): Bytes => encoder.encode(value as T);
+
+/// Debugging helper
+export const base64 = (bytes: Uint8Array) =>
+  btoa(Array.from(bytes, (c) => String.fromCodePoint(c)).join(''));

--- a/web-client/src/schema/sealing.ts
+++ b/web-client/src/schema/sealing.ts
@@ -1,0 +1,83 @@
+/** [`SealedMessage`] sealing and unsealing. */
+
+import { Nonce, PublicKey, TweetNaClCrypto } from './crypto';
+import { from_msgpack, from_msgpack_as, to_msgpack } from './msgpack';
+import { Bytes } from './types';
+
+/** A sealed message */
+export type SealedMessage = {
+  ciphertext: Bytes;
+  nonce: Nonce;
+  sender_public_key: PublicKey;
+};
+
+/** Seal message bytes from [`sender_crypto`] to [`receiver_public_key`]. */
+export const seal = (
+  message_bytes: Bytes,
+  receiver_public_key: PublicKey,
+  sender_crypto: TweetNaClCrypto
+): SealedMessage => {
+  const encrypted_message = sender_crypto.encrypt_message(
+    message_bytes,
+    receiver_public_key
+  );
+  return {
+    ciphertext: encrypted_message.ciphertext,
+    nonce: encrypted_message.nonce,
+    sender_public_key: sender_crypto.public_key,
+  };
+};
+
+/** Unseal message bytes to [`receiver_crypto`]. */
+export const unseal = (
+  sealed_message: SealedMessage,
+  receiver_crypto: TweetNaClCrypto
+): Uint8Array | null =>
+  receiver_crypto.decrypt_message(
+    sealed_message.ciphertext,
+    sealed_message.sender_public_key,
+    sealed_message.nonce
+  );
+
+// TODO: Better type handling.
+
+/** [`seal`] as MessagePack. */
+export const seal_msgpack = (
+  message: unknown,
+  receiver_public_key: PublicKey,
+  sender_crypto: TweetNaClCrypto
+): Bytes => {
+  const message_bytes = to_msgpack(message);
+  const sealed_message = seal(
+    message_bytes,
+    receiver_public_key,
+    sender_crypto
+  );
+  return to_msgpack(sealed_message);
+};
+
+/** [`unseal`] as MessagePack. */
+export const unseal_msgpack = (
+  sealed_message_bytes: Bytes,
+  receiver_crypto: TweetNaClCrypto
+): unknown | null => {
+  const sealed_message = from_msgpack_as<SealedMessage>(sealed_message_bytes);
+  const message_bytes = unseal(sealed_message, receiver_crypto);
+  if (message_bytes === null) {
+    return null;
+  }
+  return from_msgpack(message_bytes);
+};
+
+// FIXME: Placeholder casts
+
+export const seal_msgpack_as = <T>(
+  message: T,
+  receiver_public_key: PublicKey,
+  sender_crypto: TweetNaClCrypto
+): Bytes => seal_msgpack(message, receiver_public_key, sender_crypto);
+
+export const unseal_msgpack_as = <T>(
+  sealed_message_bytes: Bytes,
+  receiver_crypto: TweetNaClCrypto
+): T | null => unseal_msgpack(sealed_message_bytes, receiver_crypto) as T;

--- a/web-client/src/schema/types.ts
+++ b/web-client/src/schema/types.ts
@@ -1,0 +1,23 @@
+/** Supporting data types. */
+
+export type Bytes = Uint8Array;
+
+// Helpers for documentation:
+// XXX: See: Add Length Parameter to typed arrays #18471 https://github.com/microsoft/TypeScript/issues/18471
+export type Bytes32 = Bytes;
+export type Bytes24 = Bytes;
+
+/** Nautilus Wallet ID. */
+export type WalletId = string;
+
+/** A wallet owner's authenticating PIN. */
+export type WalletPin = string;
+
+/** Algorand account seed, as bytes. */
+export type AlgorandAccountSeedBytes = Bytes32;
+
+/** Algorand account address, as bytes. */
+export type AlgorandAddressBytes = Bytes32;
+
+/** Algorand account address, as base32 with checksum. */
+export type AlgorandAddressBase32 = string;

--- a/web-client/src/tests/test.helpers.ts
+++ b/web-client/src/tests/test.helpers.ts
@@ -34,3 +34,31 @@ const getElementWithLink = (
   expect(trigger).not.toBeNull();
   return trigger;
 };
+
+/**
+ * Resolve a promise with dynamic context provided by a callable.
+ *
+ * This is intended to make it slightly less awkward to use Promise-based code with Angular's HTTP testing pattern,
+ * which requires request expectations to be made strictly _after_ the code under test makes its requests,
+ * but _before_ awaiting completion of the code under test.
+ *
+ * With this helper, `const result = await codeUnderTest()` becomes:
+ *
+ * ```
+ * const result = await withResolveContext(codeUnderTest(), () => {
+ *   // Use httpTestingController.expectOne(…)
+ * })
+ * ```
+ *
+ * @see https://angular.io/guide/http#testing-http-requests
+ *
+ * @param promise Promise to await
+ * @param context callable to invoke before awaiting `promise`
+ */
+export const withResolveContext = async <T>(
+  promise: Promise<T>,
+  context: () => void
+): Promise<T> => {
+  context();
+  return await promise;
+};

--- a/web-client/tsconfig.json
+++ b/web-client/tsconfig.json
@@ -13,7 +13,12 @@
     "target": "es2015",
     "module": "es2020",
     "lib": ["es2018", "dom"],
-    "strict": true
+    "strict": true,
+    // XXX(Pi): Webpack 5 no longer includes a crypto polyfill by default.
+    //          This seems to be the most straightforward way to get it to work, for now.
+    "paths": {
+      "crypto": ["node_modules/crypto-js"]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
### Tasks

- [x] Sort out the `@typescript-eslint/naming-convention` lint situation
- [x] environment types

Issues:

- #25
- #26
- #27

### Deferred tasks

- ~Use https://github.com/capacitor-community/http for http calls~ – the library does not support posting binary data, it seems: we'll need upstream patches.
- WalletService test coverage: split to #74
- Schema test coverage: split to #75

### Follows

- #66 (for Chromatic baseline fix)
- #65 (for `package-lock.json` sync)