### PR TITLE
fix(web-client): remove clearInput button from lock screen PIN input

### DIFF
--- a/web-client/src/app/views/lockscreen/lockscreen.page.html
+++ b/web-client/src/app/views/lockscreen/lockscreen.page.html
@@ -20,7 +20,6 @@
             formControlName="code"
             inputmode="tel"
             autofocus="true"
-            clearInput="true"
             minlength="4"
             maxlength="10"
             [ngClass]="{'invalid': codeForm.dirty && codeForm.invalid}"


### PR DESCRIPTION
This was causing the focus ring to render out of alignment.

(This showed up in Chromatic intermittently because of a snapshot / `autofocus` race, I'm guessing.)

- Precedes #65