### PR TITLE
ci(web-client): always run GitHub Actions

### DIFF
--- a/.github/workflows/web-client.yaml
+++ b/.github/workflows/web-client.yaml
@@ -1,8 +1,4 @@
-on:
-  push:
-    paths:
-      - '.github/workflows/web-client.yaml'
-      - 'web-client/**'
+on: push
 
 defaults:
   run:


### PR DESCRIPTION
Remove the path conditions, for now, so that this builds even for server-only changes.

This simplifies our checks, for now, and will probably be needed for full client / server integration tests later.