### PR TITLE
test(web-client, LockscreenPage): default autofocus to false, for Chromatic

### DIFF
--- a/web-client/src/app/views/lockscreen/lockscreen.page.html
+++ b/web-client/src/app/views/lockscreen/lockscreen.page.html
@@ -19,7 +19,7 @@
             type="password"
             formControlName="code"
             inputmode="tel"
-            autofocus="true"
+            [autofocus]="autofocus"
             minlength="4"
             maxlength="10"
             [ngClass]="{'invalid': codeForm.dirty && codeForm.invalid}"

--- a/web-client/src/app/views/lockscreen/lockscreen.page.stories.ts
+++ b/web-client/src/app/views/lockscreen/lockscreen.page.stories.ts
@@ -17,3 +17,8 @@ const Template: Story<LockscreenPage> = (args: LockscreenPage) => ({
 });
 
 export const Default = Template.bind({});
+
+Default.args = {
+  // Disable autofocus by default, for consistent Chromatic snapshots
+  autofocus: false,
+};

--- a/web-client/src/app/views/lockscreen/lockscreen.page.ts
+++ b/web-client/src/app/views/lockscreen/lockscreen.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ModalController, ToastController } from '@ionic/angular';
 
@@ -8,6 +8,8 @@ import { ModalController, ToastController } from '@ionic/angular';
   styleUrls: ['./lockscreen.page.scss'],
 })
 export class LockscreenPage implements OnInit {
+  @Input() autofocus = true;
+
   codeForm: FormGroup;
 
   constructor(


### PR DESCRIPTION
This exposes LockscreenPage's `autofocus` as an input property, preserving the default `true`, but disabling it for Storybook.

This should avoid the inconsistent snapshots in Chromatic.