### PR TITLE
test(web-server, sgx-wallet-test): exit with error status if tests failed

### DIFF
--- a/web-server/sgx-wallet-test/app/codegen/Enclave_u.c
+++ b/web-server/sgx-wallet-test/app/codegen/Enclave_u.c
@@ -2,7 +2,7 @@
 #include <errno.h>
 
 typedef struct ms_run_tests_ecall_t {
-	sgx_status_t ms_retval;
+	size_t ms_retval;
 } ms_run_tests_ecall_t;
 
 typedef struct ms_t_global_init_ecall_t {
@@ -1259,7 +1259,7 @@ static const struct {
 		(void*)Enclave_sgx_thread_set_multiple_untrusted_events_ocall,
 	}
 };
-sgx_status_t run_tests_ecall(sgx_enclave_id_t eid, sgx_status_t* retval)
+sgx_status_t run_tests_ecall(sgx_enclave_id_t eid, size_t* retval)
 {
 	sgx_status_t status;
 	ms_run_tests_ecall_t ms;

--- a/web-server/sgx-wallet-test/app/codegen/Enclave_u.h
+++ b/web-server/sgx-wallet-test/app/codegen/Enclave_u.h
@@ -335,7 +335,7 @@ int SGX_UBRIDGE(SGX_CDECL, sgx_thread_setwait_untrusted_events_ocall, (const voi
 int SGX_UBRIDGE(SGX_CDECL, sgx_thread_set_multiple_untrusted_events_ocall, (const void** waiters, size_t total));
 #endif
 
-sgx_status_t run_tests_ecall(sgx_enclave_id_t eid, sgx_status_t* retval);
+sgx_status_t run_tests_ecall(sgx_enclave_id_t eid, size_t* retval);
 sgx_status_t t_global_init_ecall(sgx_enclave_id_t eid, uint64_t id, const uint8_t* path, size_t len);
 sgx_status_t t_global_exit_ecall(sgx_enclave_id_t eid);
 

--- a/web-server/sgx-wallet-test/app/codegen/Enclave_u.rs
+++ b/web-server/sgx-wallet-test/app/codegen/Enclave_u.rs
@@ -3,5 +3,5 @@
 use sgx_types::*;
 
 extern "C" {
-    pub fn run_tests_ecall(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
+    pub fn run_tests_ecall(eid: sgx_enclave_id_t, retval: *mut size_t) -> sgx_status_t;
 }

--- a/web-server/sgx-wallet-test/app/src/safe_ecalls.rs
+++ b/web-server/sgx-wallet-test/app/src/safe_ecalls.rs
@@ -1,0 +1,13 @@
+//! Safe Rust wrappers around [`enclave_u`].
+
+use sgx_types::{sgx_enclave_id_t, sgx_status_t, size_t, SgxResult};
+
+use crate::enclave_u;
+
+pub(crate) fn safe_run_tests_ecall(eid: sgx_enclave_id_t) -> SgxResult<size_t> {
+    let mut retval = size_t::MAX;
+    match unsafe { enclave_u::run_tests_ecall(eid, &mut retval) } {
+        sgx_status_t::SGX_SUCCESS => Ok(retval),
+        err => Err(err),
+    }
+}

--- a/web-server/sgx-wallet-test/enclave/Enclave.edl
+++ b/web-server/sgx-wallet-test/enclave/Enclave.edl
@@ -7,6 +7,6 @@ enclave {
 
     trusted
     {
-        public sgx_status_t run_tests_ecall();
+        public size_t run_tests_ecall();
     };
 };

--- a/web-server/sgx-wallet-test/enclave/codegen/Enclave_t.c
+++ b/web-server/sgx-wallet-test/enclave/codegen/Enclave_t.c
@@ -28,7 +28,7 @@
 
 
 typedef struct ms_run_tests_ecall_t {
-	sgx_status_t ms_retval;
+	size_t ms_retval;
 } ms_run_tests_ecall_t;
 
 typedef struct ms_t_global_init_ecall_t {

--- a/web-server/sgx-wallet-test/enclave/codegen/Enclave_t.h
+++ b/web-server/sgx-wallet-test/enclave/codegen/Enclave_t.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-sgx_status_t run_tests_ecall(void);
+size_t run_tests_ecall(void);
 void t_global_init_ecall(uint64_t id, const uint8_t* path, size_t len);
 void t_global_exit_ecall(void);
 

--- a/web-server/sgx-wallet-test/enclave/src/lib.rs
+++ b/web-server/sgx-wallet-test/enclave/src/lib.rs
@@ -13,10 +13,9 @@ use std::string::String;
 use std::vec::Vec;
 
 use sgx_tunittest::*;
-use sgx_types::sgx_status_t;
 
 #[no_mangle]
-pub extern "C" fn run_tests_ecall() -> sgx_status_t {
+pub extern "C" fn run_tests_ecall() -> usize {
     backtrace::enable_backtrace("enclave.signed.so", backtrace::PrintFormat::Short).unwrap();
 
     rsgx_unit_tests!(
@@ -41,7 +40,5 @@ pub extern "C" fn run_tests_ecall() -> sgx_status_t {
         wallet_operations::test_sign_transaction::sign_transaction_without_tag,
         wallet_operations::test_sign_transaction::sign_transaction_works,
         wallet_operations::test_sign_transaction_msgpack::prop_transaction_msgpack_roundtrips,
-    );
-
-    sgx_status_t::SGX_SUCCESS
+    )
 }


### PR DESCRIPTION
* wrap `enclave_u::run_tests_ecall` in `safe_run_tests_ecall`
* return failed test count from `run_tests_ecall`
* exit with error status from `main` if any tests failed