### PR TITLE
build(web-server): update Rust nightly toolchain: 2021-03-25 → 2021-05-10

### DIFF
--- a/web-server/Dockerfile
+++ b/web-server/Dockerfile
@@ -38,7 +38,8 @@
 
 # Pre-stage build args:
 
-ARG RUST_TOOLCHAIN="nightly-2021-03-25"
+# This should match rust-toolchain.toml
+ARG RUST_TOOLCHAIN="nightly-2021-05-10"
 
 # Intel SGX SDK 2.14
 # Docs: https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-linux-2.14-release

--- a/web-server/rust-toolchain.toml
+++ b/web-server/rust-toolchain.toml
@@ -1,5 +1,6 @@
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-# This crate's dependencies require Rust 1.51 for stable feature(min_const_generics)
-# https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25
-channel = "nightly-2021-03-25"
+# See: https://github.com/registreerocks/nautilus-wallet/wiki/Rust-SGX-SDK-toolchain-support-status
+#
+# This should match RUST_TOOLCHAIN in Dockerfile
+channel = "nightly-2021-05-10"


### PR DESCRIPTION
This is needed for semver, which depends on stable `feature(nonzero_leading_trailing_zeros)` (Rust 1.53).

See also: https://github.com/registreerocks/nautilus-wallet/wiki/Rust-SGX-SDK-toolchain-support-status