### PR TITLE
refactor: split out env-var-helpers library

### DIFF
--- a/asset-services/Cargo.lock
+++ b/asset-services/Cargo.lock
@@ -69,6 +69,7 @@ version = "0.1.0"
 dependencies = [
  "asset-services-celery",
  "axum",
+ "env-var-helpers",
  "log",
  "tokio",
 ]
@@ -78,6 +79,7 @@ name = "asset-services-celery"
 version = "0.1.0"
 dependencies = [
  "celery",
+ "env-var-helpers",
  "env_logger",
  "serde",
  "url",
@@ -322,6 +324,14 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "env-var-helpers"
+version = "0.1.0"
+source = "git+https://github.com/PiDelport/rust-env-var-helpers#89a15ddd524af1fbd4ab5a377d984dd990212dad"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "env_logger"

--- a/asset-services/asset-services-api/Cargo.toml
+++ b/asset-services/asset-services-api/Cargo.toml
@@ -10,4 +10,6 @@ axum = "0.2"
 log = "0.4"
 tokio = { version = "1", features = ["macros"] }
 
+env-var-helpers = { git = "https://github.com/PiDelport/rust-env-var-helpers" }
+
 asset-services-celery = { path = "../asset-services-celery" }

--- a/asset-services/asset-services-api/src/helpers.rs
+++ b/asset-services/asset-services-api/src/helpers.rs
@@ -1,18 +1,11 @@
+use std::io;
 use std::net::SocketAddr;
 use std::str::FromStr;
-use std::{env, io};
+
+use env_var_helpers::env_vars;
 
 pub fn bind_addr_from_env() -> io::Result<SocketAddr> {
-    let value = match env::var("BIND_ADDR") {
-        Err(env::VarError::NotPresent) => Ok("127.0.0.1:8081".to_string()),
-        otherwise => otherwise,
-    }
-    .map_err(|var_err| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("invalid BIND_ADDR: {}", var_err),
-        )
-    })?;
+    let value = env_vars::var_default("BIND_ADDR", "127.0.0.1:8081")?;
     SocketAddr::from_str(&value).map_err(|parse_err| {
         io::Error::new(
             io::ErrorKind::InvalidInput,

--- a/asset-services/asset-services-celery/Cargo.toml
+++ b/asset-services/asset-services-celery/Cargo.toml
@@ -13,3 +13,5 @@ url = "2"
 celery = "0.4.0-rc10"
 # The celery::task macro requires serde here.
 serde = "1.0"
+
+env-var-helpers = { git = "https://github.com/PiDelport/rust-env-var-helpers" }

--- a/asset-services/asset-services-celery/src/run_helpers.rs
+++ b/asset-services/asset-services-celery/src/run_helpers.rs
@@ -1,8 +1,9 @@
 //! Helpers for running processes that interact with a Celery task queue.
 
-use std::{env, io};
+use std::io;
 
 use celery::error::CeleryError;
+use env_var_helpers::env_vars;
 
 use crate::celery_box::CeleryBox;
 use crate::tasks;
@@ -18,12 +19,7 @@ pub fn init_logging_from_env() {
 
 /// Initialise a [`Celery`] app instance with the broker specified by the `BROKER_URL` environment variable.
 pub async fn init_celery_from_env() -> Result<CeleryBox, CeleryError> {
-    let broker_url = env::var("BROKER_URL").map_err(|var_err| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("invalid BROKER_URL: {}", var_err),
-        )
-    })?;
+    let broker_url = env_vars::var("BROKER_URL").map_err(io::Error::from)?;
     init_celery_app(&broker_url).await
 }
 

--- a/web-server/sgx-wallet/app/Cargo.lock
+++ b/web-server/sgx-wallet/app/Cargo.lock
@@ -479,6 +479,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "env-var-helpers"
+version = "0.1.0"
+source = "git+https://github.com/PiDelport/rust-env-var-helpers#8aed1f58daf2e68b880e2dc0defa3650987e69c6"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1132,7 @@ name = "sgx-wallet-app"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "env-var-helpers",
  "http-service-impl",
  "sgx-helpers",
  "sgx_types",
@@ -1261,6 +1270,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/web-server/sgx-wallet/app/Cargo.toml
+++ b/web-server/sgx-wallet/app/Cargo.toml
@@ -9,6 +9,8 @@ build = "build.rs"
 [dependencies]
 actix-web = "4.0.0-beta.8"
 
+env-var-helpers = { git = "https://github.com/PiDelport/rust-env-var-helpers", default-features = false }
+
 # SGX SDK
 sgx_types = { git = "https://github.com/apache/incubator-teaclave-sgx-sdk", rev = "d107bd0718f723221750a4f2973451b386cbf9d2" }
 sgx_urts = { git = "https://github.com/apache/incubator-teaclave-sgx-sdk", rev = "d107bd0718f723221750a4f2973451b386cbf9d2" }

--- a/web-server/sgx-wallet/app/src/main.rs
+++ b/web-server/sgx-wallet/app/src/main.rs
@@ -2,9 +2,10 @@ extern crate sgx_types;
 extern crate sgx_urts;
 
 use std::fs::create_dir_all;
+use std::io;
 use std::net::ToSocketAddrs;
-use std::{env, io};
 
+use env_var_helpers::env_vars;
 use http_service_impl::server::run_server;
 use sgx_types::{sgx_attributes_t, sgx_launch_token_t, sgx_misc_attribute_t, SgxResult};
 use sgx_urts::SgxEnclave;
@@ -52,11 +53,7 @@ async fn main() -> io::Result<()> {
     // FIXME: See WALLET_STORE_DIR
     create_dir_all("wallet_store")?;
 
-    let bind_addr = match env::var("BIND_ADDR") {
-        Err(env::VarError::NotPresent) => Ok("127.0.0.1:8080".to_string()),
-        otherwise => otherwise,
-    }
-    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    let bind_addr = env_vars::var_default("BIND_ADDR", "127.0.0.1:8080")?;
 
     for socket_addr in bind_addr.to_socket_addrs()? {
         println!("run_server: binding to http://{}/", socket_addr);


### PR DESCRIPTION
- Issue: #96 

This was originally an internal crate, but that's trickier for Docker to share, so the simplest way forward seems to be to just go ahead and split it out fully.

- Precedes: #103